### PR TITLE
support specification of dnf emitters

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ auto_update_update_cmd: default
 # (RedHat like systems only) Whether a message should be emitted when updates are available, were downloaded, or applied.
 auto_update_message: no
 
+# (RedHat like systems only) How a message should be emit results of updates. The value is a comma seperated string with
+# with one or more of these choices: email, stdio, motd.
+auto_update_message_emitters: "email, stdio, motd"
+
 # Whether updates should be downloaded when they are available.
 auto_update_download_updates: yes
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,3 +17,7 @@ auto_update_apply_updates: no
 
 # Maximum amout of time to randomly sleep, in minutes.
 auto_update_random_sleep: 360
+
+# (RedHat like systems only) How a message should be emit results of updates. The value is a comma seperated string with
+# with one or more of these choices: email, stdio, motd.
+auto_update_message_emitters: "email, stdio, motd"

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -36,3 +36,10 @@
       - auto_update_random_sleep is number
       - auto_update_random_sleep >= 0
     quiet: yes
+
+- name: assert | Test if auto_update_message_emitters is set correctly
+  ansible.builtin.assert:
+    that:
+      - auto_update_message_emitters is defined
+      - auto_update_message_emitters is string
+    quiet: yes

--- a/templates/automatic.conf.j2
+++ b/templates/automatic.conf.j2
@@ -4,3 +4,5 @@ upgrade_type = {{ auto_update_update_cmd }}
 random_sleep = {{ auto_update_random_sleep }}
 download_updates = {{ auto_update_download_updates }}
 apply_updates = {{ auto_update_apply_updates }}
+[emitters]
+emit_via = {{ auto_update_message_emitters }}


### PR DESCRIPTION
---
Support the specification of dnf update message emitters.
---

**Describe the change**
Allows the specification of which emitters to use via setting the `auto_update_message_emitters` variable

